### PR TITLE
chore: Use "assert.match" instead of "assert.ok"

### DIFF
--- a/src/extension/test/suite/extension.test.ts
+++ b/src/extension/test/suite/extension.test.ts
@@ -66,7 +66,7 @@ suite('environment vriables in teminal', () => {
     terminal.sendText('exit')
     await terminalClosedPromise
 
-    assert.ok(envText.includes('TEST_VSCODE_EXT_SERVE_RUN_WASM_IPC_PATH'))
+    assert.match(envText, /`TEST_VSCODE_EXT_SERVE_RUN_WASM_IPC_PATH=/)
   })
 })
 


### PR DESCRIPTION
This is a more specific assertion, and will give a better error message
when the test fails.
